### PR TITLE
Fix networking.py

### DIFF
--- a/software/networking/networking.py
+++ b/software/networking/networking.py
@@ -1,6 +1,5 @@
 import network
 import machine
-from config import mysecrets, configname
 import time
 import ubinascii
 import urequests
@@ -29,7 +28,7 @@ class Networking:
         self.aen = self.Aen(self)
         
         self.id = ubinascii.hexlify(machine.unique_id()).decode()
-        self.name = configname
+        self.name = None
         if self.name == "" or self.name == None:
             self.name = str(self.id)
         


### PR DESCRIPTION
In the original, you are required to have some config file with a mysecrets array. These are never actually referenced in the code and aren't required for networking.py to work. I have removed that, and set self.name to None.